### PR TITLE
capnproto 1.0.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,8 +16,8 @@ build:
     - {{ pin_subpackage('capnproto', max_pin='x.x.x') }}
   ignore_prefix_files:
     - bin/capnp
-  missing_dso_whitelist:  # [linux]
-    - $RPATH/ld64.so.1    # [linux]
+  missing_dso_whitelist:  # [s390x]
+    - $RPATH/ld64.so.1    # [s390x]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.10.4" %}
+{% set version = "1.0.1" %}
 
 package:
   name: capnproto
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://capnproto.org/capnproto-c++-{{ version }}.tar.gz
-  sha256: 981e7ef6dbe3ac745907e55a78870fbb491c5d23abd4ebc04e20ec235af4458c
+  sha256: 0f7f4b8a76a2cdb284fddef20de8306450df6dd031a47a15ac95bc43c3358e09
 
 build:
   number: 0


### PR DESCRIPTION
capnproto 1.0.1 

**Destination channel:** Defaults

### Links

- [PKG-6067]
- dev_url:        https://github.com/capnproto/capnproto/tree/v1.0.1
- conda_forge:    None
- pypi:           n/a
- pypi inspector: n/a

### Explanation of changes:

- new version number
- for tiledb 2.26.1, where it's hard pinned


[PKG-6067]: https://anaconda.atlassian.net/browse/PKG-6067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ