### PR TITLE
capnproto 1.0.1.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.0.1" %}
+{% set version = "1.0.1.1" %}
 
 package:
   name: capnproto
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://capnproto.org/capnproto-c++-{{ version }}.tar.gz
-  sha256: 0f7f4b8a76a2cdb284fddef20de8306450df6dd031a47a15ac95bc43c3358e09
+  sha256: b224e61d5b46f13967b7189860a7373b96d0c105e0d6170f29acba09a2d31f57
 
 build:
   number: 0


### PR DESCRIPTION
capnproto 1.0.1.1 

**Destination channel:** Defaults

### Links

- [PKG-6119]
- dev_url:        https://github.com/capnproto/capnproto/tree/v1.0.1.1
- conda_forge:    None
- pypi:           n/a
- pypi inspector: n/a
- diff: https://github.com/capnproto/capnproto/compare/v1.0.1...v1.0.1.1

### Explanation of changes:

- new version number
- fixes vulnerability in 1.0.1


[PKG-6119]: https://anaconda.atlassian.net/browse/PKG-6119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ